### PR TITLE
feat: chestsort (fixes #20)

### DIFF
--- a/src/main/java/dev/martinl/bsbrewritten/BSBRewritten.java
+++ b/src/main/java/dev/martinl/bsbrewritten/BSBRewritten.java
@@ -7,6 +7,7 @@ import dev.martinl.bsbrewritten.listeners.InteractListener;
 import dev.martinl.bsbrewritten.listeners.InventoryCloseListener;
 import dev.martinl.bsbrewritten.listeners.PlayerJoinListener;
 import dev.martinl.bsbrewritten.manager.ShulkerManager;
+import dev.martinl.bsbrewritten.manager.chestsort.ChestSortManagerImpl;
 import dev.martinl.bsbrewritten.util.Metrics;
 import dev.martinl.bsbrewritten.util.UpdateChecker;
 import lombok.Getter;
@@ -50,6 +51,16 @@ public class BSBRewritten extends JavaPlugin {
                 Bukkit.getConsoleSender().sendMessage(ChatColor.YELLOW + "[BSB] " + ChatColor.GRAY + "You are running the latest BetterShulkerBoxes version.");
             }
         });
+
+        if(Bukkit.getPluginManager().getPlugin("ChestSort") != null) {
+            if(getBSBConfig().isEnableChestSortHook()) {
+                shulkerManager.setChestSortManager(new ChestSortManagerImpl());
+                Bukkit.getConsoleSender().sendMessage(ChatColor.GREEN + "[BSB] BetterShulkerBoxes successfully hooked to ChestSort");
+            } else {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.YELLOW + "[BSB] BetterShulkerBoxes did not hook to ChestSort because it's disabled in the config file");
+            }
+
+        }
 
         if (getBSBConfig().isEnableStatistics()) {
             new Metrics(this, 6076);

--- a/src/main/java/dev/martinl/bsbrewritten/configuration/BSBConfig.java
+++ b/src/main/java/dev/martinl/bsbrewritten/configuration/BSBConfig.java
@@ -22,6 +22,8 @@ public class BSBConfig implements IDeepCloneable {
     private boolean enableInventoryClickOpen = true;
     private boolean disableMovementCheck = false;
 
+    private boolean enableChestSortHook = true;
+
 
     private boolean disableVulnerableVersionProtection = false;
 
@@ -46,6 +48,7 @@ public class BSBConfig implements IDeepCloneable {
                 enableRightClickOpen,
                 enableInventoryClickOpen,
                 disableMovementCheck,
+                enableChestSortHook,
                 disableVulnerableVersionProtection,
                 prefix,
                 inventoryName,

--- a/src/main/java/dev/martinl/bsbrewritten/manager/ShulkerManager.java
+++ b/src/main/java/dev/martinl/bsbrewritten/manager/ShulkerManager.java
@@ -2,8 +2,10 @@ package dev.martinl.bsbrewritten.manager;
 
 import dev.martinl.bsbrewritten.BSBRewritten;
 import dev.martinl.bsbrewritten.configuration.BSBConfig;
+import dev.martinl.bsbrewritten.manager.chestsort.IChestSortManager;
 import dev.martinl.bsbrewritten.util.BSBPermission;
 import dev.martinl.bsbrewritten.util.TimeUtils;
+import lombok.Setter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
@@ -24,6 +26,19 @@ public class ShulkerManager {
     private final BSBRewritten instance;
     private HashMap<Inventory, ShulkerOpenData> openShulkerInventories = new HashMap<>();
     private HashMap<UUID, Long> lastOpened = new HashMap<>();
+
+    @Setter
+    private IChestSortManager chestSortManager = new IChestSortManager() {
+        @Override
+        public void sort(Player player, Inventory shulkerInventory) {
+
+        }
+
+        @Override
+        public void setSortable(Inventory shulkerInventory) {
+
+        }
+    };
 
 
     public ShulkerManager(BSBRewritten instance) {
@@ -64,6 +79,10 @@ public class ShulkerManager {
         ShulkerBox shulker = (ShulkerBox) bsm.getBlockState();
         Inventory inventory = Bukkit.createInventory(null, InventoryType.SHULKER_BOX, formatShulkerPlaceholder(bsbConfig.getInventoryName(), shulkerStack));
         inventory.setContents(shulker.getInventory().getContents());
+
+        // Apply sort
+        chestSortManager.sort(player, inventory);
+
         player.openInventory(inventory);
         ItemStack clone = shulkerStack.clone();
         openShulkerInventories.put(inventory, new ShulkerOpenData(clone, player.getLocation()));

--- a/src/main/java/dev/martinl/bsbrewritten/manager/chestsort/ChestSortManagerImpl.java
+++ b/src/main/java/dev/martinl/bsbrewritten/manager/chestsort/ChestSortManagerImpl.java
@@ -1,0 +1,20 @@
+package dev.martinl.bsbrewritten.manager.chestsort;
+
+import de.jeff_media.chestsort.api.ChestSortAPI;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public class ChestSortManagerImpl implements IChestSortManager {
+    @Override
+    public void sort(Player player, Inventory shulkerInventory) {
+        //noinspection ConstantConditions
+        if(ChestSortAPI.hasSortingEnabled(player)) {
+            ChestSortAPI.sortInventory(shulkerInventory);
+        }
+    }
+
+    @Override
+    public void setSortable(Inventory shulkerInventory) {
+        ChestSortAPI.setSortable(shulkerInventory);
+    }
+}

--- a/src/main/java/dev/martinl/bsbrewritten/manager/chestsort/IChestSortManager.java
+++ b/src/main/java/dev/martinl/bsbrewritten/manager/chestsort/IChestSortManager.java
@@ -1,0 +1,10 @@
+package dev.martinl.bsbrewritten.manager.chestsort;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public interface IChestSortManager {
+    void sort(Player player, Inventory shulkerInventory);
+
+    void setSortable(Inventory shulkerInventory);
+}


### PR DESCRIPTION
This adds support for [chestsort ](https://www.spigotmc.org/resources/chestsort-api.59773/), a plugin that adds inventory-sorting features. Players can now have their shulkerboxes automatically sorted when opened, and/or sort them manually by double-clicking an empty space, among other features implemented by chestsort.