### PR TITLE
Fixed formatting and made french translation more uniform to the others

### DIFF
--- a/translations/bu_bu.yml
+++ b/translations/bu_bu.yml
@@ -1,6 +1,6 @@
 prefix: '&b[&eBSB&b]' # String - Chat prefix, do not add a space or any other characters after it
-inventory_name: '< %shulker_name% >' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
-open_message: '&7Отваря се (%shulker_name%)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
-close_message: '&7Затваря се (%shulker_name%)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
+inventory_name: '< %shulker_name% &r>' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
+open_message: '&7Отваря се (%shulker_name%&r)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
+close_message: '&7Затваря се (%shulker_name%&r)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
 no_permission_message: '&cНямате права за това' # String - Message to be sent to players who don't have permissions to use certain features of the plugin
 cooldown_message: '&cТрябва да изчакате %minutes% минути и %seconds% секунди преди да използвате този shulkerbox отново' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining

--- a/translations/cz_cz.yml
+++ b/translations/cz_cz.yml
@@ -1,7 +1,7 @@
 # Messages
 prefix: '&b[&eBSB&b]' # Prefix v chatu. Nedávej za něj žádné mezery nebo jiné znaky.
-inventory_name: '< %shulker_name% >' # String - Text který bude napsán při otevřeném shulkeru, použij %shulker_name% pro zobrazení jména shulkeru.
-open_message: '&7Otevírání shulkeru (%shulker_name%)...' #String - Zpráva zobrazovaná při otevírání shulkeru, použij %shulker_name% pro zobrazení jeho názvu, ponechej prázdné pro vypnutí zprávy
-close_message: '&7Zavírání shulkeru (%shulker_name%)...' #String - Zpráva zobrazovaná při zavírání shulkeru, použij %shulker_name% pro zobrazení jeho názvu, ponechej prázdné pro vypnutí zprávy
+inventory_name: '< %shulker_name% &r>' # String - Text který bude napsán při otevřeném shulkeru, použij %shulker_name% pro zobrazení jména shulkeru.
+open_message: '&7Otevírání shulkeru (%shulker_name%&r)...' #String - Zpráva zobrazovaná při otevírání shulkeru, použij %shulker_name% pro zobrazení jeho názvu, ponechej prázdné pro vypnutí zprávy
+close_message: '&7Zavírání shulkeru (%shulker_name%&r)...' #String - Zpráva zobrazovaná při zavírání shulkeru, použij %shulker_name% pro zobrazení jeho názvu, ponechej prázdné pro vypnutí zprávy
 no_permission_message: '&cNedostatečná oprávnění' # String - Zpráva, která bude odeslána, pokud hráč nemá právo na použití některých funkcí pluginu
 cooldown_message: '&cVyčkej ještě %minutes% minut a %seconds% sekund před otevřením shulkeru' # - String - Zpráva, která bude poslána hráčům s cooldownem, použij %minutes% a %seconds% pro zobrazení času

--- a/translations/de_DE.yml
+++ b/translations/de_DE.yml
@@ -1,7 +1,7 @@
 #Messages
 prefix: '&b[&eBSB&b]' # String - Chat prefix, do not add a space or any other characters after it
-inventory_name: '< %shulker_name% >' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
-open_message: '&7Öffne Shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
-close_message: '&7Schliesse Shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
+inventory_name: '< %shulker_name% &r>' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
+open_message: '&7Öffne Shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
+close_message: '&7Schliesse Shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
 no_permission_message: '&cDu hast keine Berechtigung dies auszuführen' # String - Message to be sent to players who don't have permissions to use certain features of the plugin
 cooldown_message: '&cDu musst %minutes% Minuten und %seconds% Sekunden warten, bevor du erneut eine Shulkerbox öffnen kannst' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining

--- a/translations/en_us.yml
+++ b/translations/en_us.yml
@@ -1,7 +1,7 @@
 #Messages
 prefix: '&b[&eBSB&b]' # String - Chat prefix, do not add a space or any other characters after it
-inventory_name: '< %shulker_name% >' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
-open_message: '&7Opening shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
-close_message: '&7Closing shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
+inventory_name: '< %shulker_name% &r>' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
+open_message: '&7Opening shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
+close_message: '&7Closing shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
 no_permission_message: '&cNo permission' # String - Message to be sent to players who don't have permissions to use certain features of the plugin
 cooldown_message: '&cYou have to wait %minutes% minutes and %seconds% before using this again' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining

--- a/translations/es_es.yml
+++ b/translations/es_es.yml
@@ -1,7 +1,7 @@
 #Messages
 prefix: '&b[&eBSB&b]' # String - Chat prefix, do not add a space or any other characters after it
-inventory_name: '< %shulker_name% >' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
-open_message: '&7Abriendo shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
-close_message: '&7Cerrando shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
+inventory_name: '< %shulker_name% &r>' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
+open_message: '&7Abriendo shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
+close_message: '&7Cerrando shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
 no_permission_message: '&cSin permisos.' # String - Message to be sent to players who don't have permissions to use certain features of the plugin
 cooldown_message: '&cTienes que esperar %minutes% minutos y  %seconds% segundos antes de usar esto de nuevo!' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining

--- a/translations/fr_fr.yml
+++ b/translations/fr_fr.yml
@@ -1,7 +1,6 @@
 prefix: '&b[&eBSB&b]' # String - Chat prefix, do not add a space or any other characters after it
-inventory_name: < %shulker_name% > # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
-open_message: '&7&lOuverture de %shulker_name%...' # String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
-close_message: '&7&lFermeture de %shulker_name%...' # String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
+inventory_name: < %shulker_name% &r> # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
+open_message: '&7&lOuverture de (%shulker_name%&r)...' # String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
+close_message: '&7&lFermeture de (%shulker_name%&r)...' # String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
 no_permission_message: '&cVous n''avez pas le permission' # String - Message to be sent to players who don't have permissions to use certain features of the plugin
-cooldown_message: '&cVous devez attendre %minutes% minutes et %seconds% pour utiliser
-  cette mÃ©canique.' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining
+cooldown_message: '&cVous devez attendre %minutes% minutes et %seconds% pour utiliser cette mÃ©canique.' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining

--- a/translations/it_it.yml
+++ b/translations/it_it.yml
@@ -1,7 +1,7 @@
 #Messages
 prefix: '&b[&eBSB&b]' # String - Chat prefix, do not add a space or any other characters after it
-inventory_name: '< %shulker_name% >' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
-open_message: '&7Aprendo la shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
-close_message: '&7Chiudendo la shulkerbox (%shulker_name%)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
+inventory_name: '< %shulker_name% &r>' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
+open_message: '&7Aprendo la shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
+close_message: '&7Chiudendo la shulkerbox (%shulker_name%&r)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
 no_permission_message: '&cNon hai il permesso!' # String - Message to be sent to players who don't have permissions to use certain features of the plugin
 cooldown_message: '&cDevi aspettare %minutes% minuti e %seconds% secondi prima di riaprire la shulkerbox!' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining

--- a/translations/zh_cn.yml
+++ b/translations/zh_cn.yml
@@ -1,7 +1,7 @@
 #Messages
 prefix: '&b[&eBSB&b]' # String - Chat prefix, do not add a space or any other characters after it
-inventory_name: '< %shulker_name% >' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
-open_message: '&7打开潜影盒中 (%shulker_name%)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
-close_message: '&7关闭潜影盒中 (%shulker_name%)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
+inventory_name: '< %shulker_name% &r>' # String - Text to be displayed as the inventory title, use %shulker_name% to display the item name
+open_message: '&7打开潜影盒中 (%shulker_name%&r)...' #String - Message to be sent to a player when they open a shulker box, use %shulker_name% to display the item name, leave empty to disable
+close_message: '&7关闭潜影盒中 (%shulker_name%&r)...' #String - Message to be sent to a player when they close a shulker box, use %shulker_name% to display the item name, leave empty to disable
 no_permission_message: '&c你没有权限' # String - Message to be sent to players who don't have permissions to use certain features of the plugin
 cooldown_message: '&c你必须等待 %minutes%分%seconds%秒 后才能再次使用这个。' # - String - Message to be sent to players who have to wait for the cooldown, use %minutes% and %seconds% to display the time remaining


### PR DESCRIPTION
Fixed that the brackets after the Shulker Box name in openening and closing massages are formatted, if the shulker box's name is formatted. This also fixes the 3 dots at the end being formatted.

I also made the french translation look more like the other languages and removed the falsely placed new line in the cooldown message.