### PR TITLE
Keep cursor item when opening a shulkerbox.

### DIFF
--- a/src/main/java/dev/martinl/bsbrewritten/manager/ShulkerManager.java
+++ b/src/main/java/dev/martinl/bsbrewritten/manager/ShulkerManager.java
@@ -66,6 +66,10 @@ public class ShulkerManager {
             return;
         }
 
+        // Cursor item is not keept when opening a new inventory, keep it manually.
+        ItemStack cursorItem = player.getItemOnCursor();
+        // It is "keept" when closing your inventory, but not in your cursor, make sure it's not duplicated.
+        player.setItemOnCursor(null);
 
         // close the player's current inventory if they have one open
         if (player.getOpenInventory().getTopInventory().getType() != InventoryType.CRAFTING||
@@ -88,6 +92,8 @@ public class ShulkerManager {
         chestSortManager.sort(player, inventory);
 
         player.openInventory(inventory);
+        // Restore the cursor item
+        player.setItemOnCursor(cursorItem);
         ItemStack clone = shulkerStack.clone();
         openShulkerInventories.put(inventory, new ShulkerOpenData(clone, player.getLocation(), slotType, rawSlot));
 


### PR DESCRIPTION
Fixes #40 and #49.

Keeps the current cursor item when opening a shulker, fixing the issue of cursor items being deleted when right-clicking a shulker in your inventory when not already having a shulker opened. Also has the added effect of making it easier to move stuff between shulkers.

The root cause of the issue is that player.openInventory deletes the cursor item if it exists. If you already have a shulker open, the player.closeInventory that happens earlier puts the cursor item in the player inventory, or drops it if there is no space.

This PR saves the cursor item and then sets the cursor item to null before closing the previous inventory, restoring cursor item back to the saved item after opening the shulker, making sure the call to closeInventory does not cause item duplication.