### PR TITLE
Fix inventory desync by waiting 1 tick.

### DIFF
--- a/src/main/java/dev/martinl/bsbrewritten/listeners/InteractListener.java
+++ b/src/main/java/dev/martinl/bsbrewritten/listeners/InteractListener.java
@@ -3,6 +3,7 @@ package dev.martinl.bsbrewritten.listeners;
 import dev.martinl.bsbrewritten.BSBRewritten;
 import dev.martinl.bsbrewritten.manager.SlotType;
 import dev.martinl.bsbrewritten.util.MaterialUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -66,7 +67,14 @@ public class InteractListener implements Listener {
         }
         if(!isShulker) return;
         e.setCancelled(true);
-        instance.getShulkerManager().openShulkerBoxInventory(player, clicked, SlotType.INVENTORY, e.getRawSlot());
-
+        ItemStack oldItem = clicked.clone();
+        // Run the handler in 1 tick to not desync the inventory.
+        Bukkit.getScheduler().runTask(instance, () ->
+            {
+                // Make sure the item has not changed since the click.
+                if (oldItem.equals(clicked)) {
+                    instance.getShulkerManager().openShulkerBoxInventory(player, clicked, SlotType.INVENTORY, e.getRawSlot());
+                }
+            });
     }
 }

--- a/src/main/java/dev/martinl/bsbrewritten/listeners/InteractListener.java
+++ b/src/main/java/dev/martinl/bsbrewritten/listeners/InteractListener.java
@@ -69,12 +69,12 @@ public class InteractListener implements Listener {
         e.setCancelled(true);
         ItemStack oldItem = clicked.clone();
         // Run the handler in 1 tick to not desync the inventory.
-        Bukkit.getScheduler().runTask(instance, () ->
-            {
-                // Make sure the item has not changed since the click.
-                if (oldItem.equals(clicked)) {
-                    instance.getShulkerManager().openShulkerBoxInventory(player, clicked, SlotType.INVENTORY, e.getRawSlot());
-                }
-            });
+        Bukkit.getScheduler().runTask(instance, () -> {
+            ItemStack currentItem = clickedInventory.getItem(e.getSlot());
+            // Make sure the item has not changed since the click.
+            if (oldItem.equals(currentItem)) {
+                instance.getShulkerManager().openShulkerBoxInventory(player, currentItem, SlotType.INVENTORY, e.getRawSlot());
+            }
+        });
     }
 }


### PR DESCRIPTION
Fixes #52 

Reading the following from the Bukkit API:
> The following should never be invoked by an EventHandler for InventoryClickEvent using the HumanEntity or InventoryView associated with this event:
> 
> HumanEntity.closeInventory()
> HumanEntity.openInventory(Inventory)
> HumanEntity.openWorkbench(Location, boolean)
> HumanEntity.openEnchanting(Location, boolean)
> InventoryView.close()
> To invoke one of these methods, schedule a task using BukkitScheduler.runTask(Plugin, Runnable), which will run the task on the next tick. Also be aware that this is not an exhaustive list, and other methods could potentially create issues as well.

I'm personally not the most experienced when it comes to working with Bukkit, but the current InventoryClickEvent handler does in fact call both closeInventory and openInventory, which is why I followed the API:s recommendation and delayed execution of openShulkerBoxInventory by 1 tick. For safety, I also added a check to make sure that the item right-clicked has not changed since the click, as clients otherwise have a 1 tick window to do bad stuff, such as replacing the shulker being opened.

This is the solution used by me on my personal server, if there is a better solution someone more experienced can come up with, I'd be all ears.

All in all I'd still recommend more testing to make sure that there isn't any edge-cases where items can be duplicated.