### PR TITLE
Cancel commands while a BSB shulker is open.

### DIFF
--- a/src/main/java/dev/martinl/bsbrewritten/listeners/InventoryCloseListener.java
+++ b/src/main/java/dev/martinl/bsbrewritten/listeners/InventoryCloseListener.java
@@ -11,6 +11,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.*;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -179,6 +180,15 @@ public class InventoryCloseListener implements Listener {
      * */
     @EventHandler
     public void onItemFrameInteract(PlayerInteractEntityEvent e){
+        cancelIfPlayerHasShulkerOpen(e.getPlayer(), e);
+    }
+
+    /*
+     * This should prevent players from putting a BSB shulker in auction
+     * (or otherwise use commands to remove it from their inventory) while having a BSB shulker open
+     */
+    @EventHandler
+    public void onPlayerCommandPreprocessEvent(PlayerCommandPreprocessEvent e){
         cancelIfPlayerHasShulkerOpen(e.getPlayer(), e);
     }
 


### PR DESCRIPTION
This should fix issues related to commands that remove the BSB shulker currently opened, be it putting in on auction, moving it to a separate storage or anything similar. Should block all execution of commands while having a BSB shulker open. You can execute commands while having a shulkerbox open using a hacked-client.

(This can not protect against other plugins which have a delay in their command execution, but fixing that would require quite a re-write).